### PR TITLE
fix: Grant security-events write permission for SAST upload

### DIFF
--- a/.github/workflows/build-single-service.yml
+++ b/.github/workflows/build-single-service.yml
@@ -32,6 +32,8 @@ on:
 jobs:
   build-service:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Adds `security-events: write` permission to the `build-service` job in `build-single-service.yml`. This is required to allow the `upload-sarif` action to successfully upload Bandit's SAST results to GitHub Code Scanning, resolving "Resource not accessible by integration" errors.

This resolves #2 