### PR TITLE
ci(codecov): Integrate Codecov for unit test coverage reporting and a…

### DIFF
--- a/.github/workflows/build-single-service.yml
+++ b/.github/workflows/build-single-service.yml
@@ -104,6 +104,15 @@ jobs:
           name: coverage-report-${{ inputs.service_name }}
           path: src/${{ inputs.service_name }}/coverage.xml
 
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: src/${{ inputs.service_name }}/coverage.xml
+          disable_search: true
+          flags: unittests
+          verbose: true
+
   # Job 2: Build and Push Docker Image (depends on security scans passing)
   build-and-push:
     needs: security-scans

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI/CD Status](https://github.com/jojees/project-genesis/actions/workflows/k8s-deploy.yaml/badge.svg)](https://github.com/jojees/project-genesis/actions/workflows/k8s-deploy.yaml)
 --->
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![codecov](https://codecov.io/github/jojees/project-genesis/graph/badge.svg?token=E6244R8XGA)](https://codecov.io/github/jojees/project-genesis)
 [![Code Scanning status](https://github.com/jojees/project-genesis/actions/workflows/build-python-services.yml/badge.svg)](https://github.com/jojees/project-genesis/security/code-scanning)
 
 ---


### PR DESCRIPTION
…dd badges

Integrates Codecov.io into the GitHub Actions workflow to automate unit test coverage reporting. This provides continuous visibility into code quality.

- **Workflow (`.github/workflows/build-single-service.yml`):**
    - Added a step to upload `coverage.xml` reports to Codecov using `codecov/codecov-action@v5`.
- **README (`README.md`):**
    - Added Codecov coverage badges to prominently display the test coverage status.

This closes #32 