### PR TITLE
feat: Stabilize Python test suite for environment independence

### DIFF
--- a/src/notification-service/tests/conftest.py
+++ b/src/notification-service/tests/conftest.py
@@ -1,58 +1,160 @@
-import pytest
-import unittest.mock as mock
 import os
 import sys
-import importlib
+import pytest
+import unittest.mock as mock
+import asyncio # Needed for asyncio mocks
 
-@pytest.fixture(autouse=True)
-def reset_modules_for_tests():
+# Import BaseSettings AFTER sys.path is guaranteed to be set
+from pydantic_settings.main import BaseSettings
+
+# --- CRITICAL: Add the root of the notification_service package to sys.path ---
+# If conftest.py is at:
+# /Users/jojijohny/Data/repos/kubernetesLab/src/notification-service/tests/conftest.py
+#
+# os.path.dirname(__file__) gives:
+# /Users/jojijohny/Data/repos/kubernetesLab/src/notification-service/tests/
+#
+# os.path.join(os.path.dirname(__file__), '..') gives:
+# /Users/jojijohny/Data/repos/kubernetesLab/src/notification-service/
+#
+# This is the directory that contains the 'notification_service' Python package.
+_app_root_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if _app_root_path not in sys.path:
+    sys.path.insert(0, _app_root_path)
+    print(f"\n--- Added {_app_root_path} to sys.path (absolute top of conftest) ---")
+
+
+@pytest.fixture(autouse=True, scope='session') # Use session scope for this global setup
+def mock_pydantic_settings_and_logger():
     """
-    Fixture to remove application modules and Pydantic-related modules from sys.modules
-    before each test to ensure a completely clean slate for imports and patching.
-    Also adds the project root to sys.path for module discovery.
+    Globally mocks Pydantic's BaseSettings to prevent environment variable
+    loading and validation errors, and mocks the application logger.
+    This fixture runs once per test session.
     """
+    # Define the mock values that Config() should always return
+    mock_config_values = {
+        "rabbitmq_host": "mock_rabbitmq_host",
+        "rabbitmq_port": 5672,
+        "rabbitmq_user": "mock_rabbitmq_user",
+        "rabbitmq_pass": "mock_rabbitmq_pass",
+        "rabbitmq_alert_queue": "mock_audit_alerts",
+        "pg_host": "mock_pg_host",
+        "pg_port": 5432,
+        "pg_db": "mock_pg_db",
+        "pg_user": "mock_pg_user",
+        "pg_password": "mock_pg_password",
+        "service_name": "mock-notification-service",
+        "environment": "test",
+        "log_level": "INFO",
+        "api_host": "0.0.0.0",
+        "api_port": 8000,
+    }
+
+    # 1. Patch BaseSettings._settings_build_values
+    # This is the most direct way to bypass Pydantic's env var loading.
+    patch_pydantic_build_values = mock.patch.object(
+        BaseSettings,
+        '_settings_build_values',
+        return_value=mock_config_values
+    )
+    _mock_pydantic_build_values = patch_pydantic_build_values.start()
+    print(f"--- Successfully patched BaseSettings._settings_build_values ---")
+
+
+    # 2. Mock the application logger
+    mock_logger_instance = mock.Mock(name="GlobalLoggerInstance")
+    mock_logger_instance.info = mock.Mock()
+    mock_logger_instance.error = mock.Mock()
+    mock_logger_instance.exception = mock.Mock()
+    mock_logger_instance.debug = mock.Mock()
+    mock_logger_instance.warning = mock.Mock()
+
+    # Patch the logger in notification_service.logger_config
+    patch_logger = mock.patch(
+        'notification_service.logger_config.logger', # Target using string path
+        new=mock_logger_instance
+    )
+    _mock_logger = patch_logger.start()
+    print(f"--- Successfully patched notification_service.logger_config.logger ---")
+
+    # 3. Patch load_config and Config class (using string paths)
+    # These are still useful for tests that explicitly call load_config() or Config()
+    # and expect a mock, even if BaseSettings._settings_build_values handles the core validation.
+    patch_load_config = mock.patch(
+        'notification_service.config.load_config',
+        return_value=mock.Mock(**mock_config_values) # Return a mock Config instance with values
+    )
+    patch_config_class = mock.patch(
+        'notification_service.config.Config',
+        return_value=mock.Mock(**mock_config_values) # Return a mock Config instance when Config() is called
+    )
+    _mock_load_config = patch_load_config.start()
+    _mock_config_class = patch_config_class.start()
+    print(f"--- Successfully patched notification_service.config.load_config and Config class ---")
+
+    # 4. Global patches for asyncio functions
+    patch_create_task = mock.patch('asyncio.create_task', wraps=asyncio.create_task)
+    patch_gather = mock.patch('asyncio.gather', wraps=asyncio.gather)
+    patch_asyncio_run = mock.patch('asyncio.run')
+
+    _mock_create_task = patch_create_task.start()
+    _mock_gather = patch_gather.start()
+    _mock_asyncio_run = patch_asyncio_run.start()
+    print(f"--- Successfully patched asyncio functions ---")
+
+
+    yield {
+        "mock_config_values": mock_config_values,
+        "mock_logger_instance": mock_logger_instance,
+        "mock_pydantic_build_values_patch": _mock_pydantic_build_values,
+        "mock_logger_patch": _mock_logger,
+        "mock_load_config_patch": _mock_load_config,
+        "mock_config_class_patch": _mock_config_class,
+        "mock_create_task": _mock_create_task,
+        "mock_gather": _mock_gather,
+        "mock_asyncio_run": _mock_asyncio_run,
+    }
+
+    # Stop all patches after the session
+    patch_pydantic_build_values.stop()
+    patch_logger.stop()
+    patch_load_config.stop()
+    patch_config_class.stop()
+    patch_create_task.stop()
+    patch_gather.stop()
+    patch_asyncio_run.stop()
+
+
+@pytest.fixture(autouse=True, scope='function')
+def setup_test_environment_per_function():
+    """
+    Fixture to clear relevant application modules from sys.modules before each test function.
+    This ensures each test gets a fresh import of application code, picking up global mocks
+    OR allowing test_config/test_logger_config to re-import the un-mocked versions.
+    """
+    # Store original sys.modules for restoration
     original_sys_modules = sys.modules.copy()
-    
-    # List of modules specific to notification-service that might be imported
-    # and need to be cleared for clean state between tests.
-    modules_to_remove = [
-        'notification_service',
-        'notification_service.main',
-        'notification_service.api',
-        'notification_service.config',
-        'notification_service.logger_config',
-        'notification_service.postgres_service',
-        'notification_service.rabbitmq_consumer',
-        # FIX: Explicitly remove pika.adapters.asyncio_connection to ensure patching works
-        'pika.adapters.asyncio_connection', 
-        'pydantic',
-        'pydantic_settings',
-        'pydantic_core',
-        'dotenv', # Also clear dotenv as it's being patched
+
+    modules_to_clear_prefixes = [
+        # Removed 'notification_service' from this list.
+        # It's crucial for the session-scoped Pydantic mock to remain effective.
+        'pika', # Top-level pika package
+        'asyncpg', # Add asyncpg to clear
+        'dotenv', # Explicitly target dotenv
     ]
-    for module_name in modules_to_remove:
-        if module_name in sys.modules:
-            del sys.modules[module_name]
 
-    print(f"\n--- Cleared {len(modules_to_remove)} application modules from sys.modules ---")
+    for module_name in list(sys.modules.keys()):
+        for prefix in modules_to_clear_prefixes:
+            if module_name == prefix or module_name.startswith(f"{prefix}."):
+                if module_name in sys.modules:
+                    del sys.modules[module_name]
+                break 
 
-    # Add the parent directory of 'notification_service' to sys.path
-    # This allows 'notification_service.config' to be imported correctly.
-    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-    if project_root not in sys.path:
-        sys.path.insert(0, project_root)
-        print(f"--- Added {project_root} to sys.path ---")
+    print(f"--- Cleared non-app modules from sys.modules for new test ---")
 
     yield # Run the test
 
-    # Remove the added path from sys.path
-    if project_root in sys.path:
-        sys.path.remove(project_root)
-        print(f"--- Removed {project_root} from sys.path ---")
-
+    # Teardown: Restore original sys.modules
     sys.modules.clear()
     sys.modules.update(original_sys_modules)
-    print("--- Restored original sys.modules ---")
-
-# Removed the mock_env_vars fixture as environment variables will be managed
-# directly within each test function for better isolation.
+    print("--- Restored original sys.modules after test ---")

--- a/src/notification-service/tests/test_api_healthz.py
+++ b/src/notification-service/tests/test_api_healthz.py
@@ -6,73 +6,57 @@ import importlib
 import json
 from quart import Quart # Import Quart for mocking the app
 
-# Add the project root to sys.path to resolve ModuleNotFoundError
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+# The sys.path.insert is now handled by pytest_configure in conftest.py
+# Remove this line from individual test files:
+# sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
 
 @pytest.fixture
-def api_healthz_mocks():
+# Inject the global_mocks fixture from conftest.py
+def api_healthz_mocks(mock_pydantic_settings_and_logger):
     """
     Pytest fixture to provide common mock objects and context for /healthz API tests.
-    Sets up a mocked Quart app, PostgreSQLService, and logger.
+    Sets up a mocked Quart app and PostgreSQLService.
+    It relies on global mocks from conftest.py for Config and logger.
     """
-    # Mock Config object (needed for config.py which is imported by api.py)
-    mock_config = mock.Mock(name="Config")
-    mock_config.rabbitmq_host = "dummy"
-    mock_config.rabbitmq_port = 1234
-    mock_config.rabbitmq_user = "dummy"
-    mock_config.rabbitmq_pass = "dummy"
-    mock_config.rabbitmq_alert_queue = "dummy"
-    mock_config.pg_host = "dummy"
-    mock_config.pg_port = 1234
-    mock_config.pg_db = "dummy"
-    mock_config.pg_user = "dummy"
-    mock_config.pg_password = "dummy"
-    mock_config.service_name = "notification-service"
-    mock_config.environment = "test"
-    mock_config.log_level = "INFO"
-    mock_config.api_host = "0.0.0.0"
-    mock_config.api_port = 8000
+    # We no longer need to define mock_config or mock_logger_instance locally
+    # for *patching purposes*, as they are provided globally by
+    # mock_pydantic_settings_and_logger.
+    # However, we still need references to them for assertions or for passing
+    # to the yielded dictionary.
+
+    # Access the globally mocked config instance and logger instance
+    # from the injected fixture.
+    mock_config = mock_pydantic_settings_and_logger["mock_config_values"]
+    mock_logger_instance = mock_pydantic_settings_and_logger["mock_logger_instance"]
 
     # Mock PostgreSQLService instance
     mock_pg_service = mock.Mock(name="PostgreSQLService")
 
-    # Mock logger instance
-    mock_logger_instance = mock.Mock(name="LoggerInstance")
-    mock_logger_instance.info = mock.Mock()
-    mock_logger_instance.error = mock.Mock()
-    mock_logger_instance.exception = mock.Mock()
-    mock_logger_instance.debug = mock.Mock()
-    mock_logger_instance.warning = mock.Mock()
+    # --- REMOVE ALL LOCAL PATCHING FOR OS.ENVIRON, DOTENV, CONFIG, AND LOGGER ---
+    # These are now handled globally by conftest.py's fixtures.
+    # The `with mock.patch.dict(os.environ, ...)` and nested patches are removed.
 
-    # Patch os.environ and dotenv functions for config loading
-    with mock.patch.dict(os.environ, {}, clear=True), \
-         mock.patch('dotenv.load_dotenv', return_value=True), \
-         mock.patch('dotenv.find_dotenv', return_value=None):
-        
-        # Patch the logger in logger_config before importing api
-        with mock.patch('notification_service.logger_config.logger', new=mock_logger_instance):
-            # Patch the config.load_config to return our mock_config
-            with mock.patch('notification_service.config.load_config', return_value=mock_config):
-                # Import the api module *after* its dependencies are mocked
-                _api_module = importlib.import_module('notification_service.api')
+    # Import the api module. It will automatically pick up the globally mocked
+    # config and logger because sys.path is set and BaseSettings is patched.
+    _api_module = importlib.import_module('notification_service.api')
 
-                # Create a Quart app instance
-                app = Quart(__name__)
-                
-                # Register the API routes onto the mock app
-                _api_module.register_api_routes(app, mock_pg_service)
+    # Create a Quart app instance
+    app = Quart(__name__)
+    
+    # Register the API routes onto the mock app
+    _api_module.register_api_routes(app, mock_pg_service)
 
-                # Create a test client for the app
-                test_client = app.test_client()
+    # Create a test client for the app
+    test_client = app.test_client()
 
-                yield {
-                    "mock_config": mock_config,
-                    "mock_pg_service": mock_pg_service,
-                    "mock_logger_instance": mock_logger_instance,
-                    "_api_module": _api_module,
-                    "app": app,
-                    "test_client": test_client,
-                }
+    yield {
+        "mock_config": mock_config, # This is the globally mocked config's values
+        "mock_pg_service": mock_pg_service,
+        "mock_logger_instance": mock_logger_instance, # This is the globally mocked logger
+        "_api_module": _api_module,
+        "app": app,
+        "test_client": test_client,
+    }
 
 @pytest.mark.asyncio
 async def test_healthz_endpoint_returns_200_ok(api_healthz_mocks):

--- a/src/notification-service/tests/test_config.py
+++ b/src/notification-service/tests/test_config.py
@@ -5,10 +5,7 @@ import importlib
 from pydantic import ValidationError # Import ValidationError for testing
 from pydantic_settings import BaseSettings # Import BaseSettings to patch its internal method
 import dotenv # Import dotenv to correctly patch dotenv_values
-
-
-# No longer relying on mock_env_vars fixture from conftest.py,
-# managing env vars directly within each test.
+import sys # Import sys to manipulate sys.modules
 
 def test_config_loads_all_env_vars_correctly():
     """
@@ -16,6 +13,19 @@ def test_config_loads_all_env_vars_correctly():
     and that their values match the mocked environment variables.
     """
     print("\n--- Test: Config Loads All Environment Variables Correctly ---")
+
+    # CRITICAL: Stop all active patches from conftest.py for this test
+    # This allows us to control the environment explicitly for this test.
+    mock.patch.stopall()
+
+    # IMPORTANT: Delete the module from sys.modules to force a fresh import
+    # This ensures the module is loaded without any global patches applied.
+    if 'notification_service.config' in sys.modules:
+        del sys.modules['notification_service.config']
+    # Also clear logger_config if it was imported and instantiated Config
+    if 'notification_service.logger_config' in sys.modules:
+        del sys.modules['notification_service.logger_config']
+
 
     mock_env = {
         "RABBITMQ_HOST": "mock_rabbitmq_host",
@@ -79,6 +89,15 @@ def test_config_parses_data_types_correctly():
     """
     print("\n--- Test: Config Parses Data Types Correctly ---")
 
+    # CRITICAL: Stop all active patches from conftest.py for this test
+    mock.patch.stopall()
+
+    # IMPORTANT: Delete the module from sys.modules to force a fresh import
+    if 'notification_service.config' in sys.modules:
+        del sys.modules['notification_service.config']
+    if 'notification_service.logger_config' in sys.modules:
+        del sys.modules['notification_service.logger_config']
+
     # Define environment variables with string values that should be parsed
     mock_env = {
         "RABBITMQ_HOST": "another_host",
@@ -135,6 +154,15 @@ def test_config_validation_for_invalid_types():
     are provided with values that cannot be parsed into their specified data types.
     """
     print("\n--- Test: Config Validation for Invalid Types ---")
+
+    # CRITICAL: Stop all active patches from conftest.py for this test
+    mock.patch.stopall()
+
+    # IMPORTANT: Delete the module from sys.modules to force a fresh import
+    if 'notification_service.config' in sys.modules:
+        del sys.modules['notification_service.config']
+    if 'notification_service.logger_config' in sys.modules:
+        del sys.modules['notification_service.logger_config']
 
     # Define environment variables with invalid types for integer fields
     mock_env = {


### PR DESCRIPTION
This commit focuses on enhancing the robustness and reliability of the Python test suite, specifically addressing issues related to environment variable loading and test isolation.

Key changes in the committed files:

- **`tests/conftest.py`**:
    - Re-introduced and refined the session-scoped fixture to globally patch `pydantic_settings.main.BaseSettings._settings_build_values`. This is crucial for providing mocked configuration values to all tests, preventing `ValidationError` when no `.env` file is present.
    - Ensured consistent global mocking for `notification_service.logger_config.logger`, `notification_service.config.load_config`, `notification_service.config.Config`, and `asyncio` functions.
    - Adjusted the `setup_test_environment_per_function` fixture to selectively clear `sys.modules` for external libraries (`pika`, `asyncpg`, `dotenv`), allowing the core `notification_service` modules to remain loaded under the session-scoped mocks.
- **`tests/test_api_healthz.py`**:
    - Simplified its setup by removing redundant local environment patching, now relying entirely on the robust global mocks provided by `conftest.py`.
- **`tests/test_config.py`**:
    - Implemented explicit `unittest.mock.patch.stopall()` and `del sys.modules['notification_service.config']` at the start of each test function. This ensures these tests can bypass the global mocks and accurately verify the application's configuration loading logic against controlled environment variables.
- **`tests/test_logger_config.py`**:
    - Applied similar explicit `unittest.mock.patch.stopall()` and `del sys.modules[...]` for test isolation.
    - Corrected a `NameError` by ensuring mock logger instances were defined in the correct scope before being referenced in patch side effects.

**Outcome:** The test suite now passes consistently both with and without a local `.env` file, significantly improving developer experience and CI/CD reliability.

This closes #28 