### PR TITLE
Dashboard in test-afp already uses nodeport 30081, so using diffenent…

### DIFF
--- a/k8s/charts/values-dev.yaml
+++ b/k8s/charts/values-dev.yaml
@@ -16,6 +16,8 @@ event-audit-dashboard:
   enabled: true
   image:
     tag: dev
+  ports:
+    nodePort: "30090"
 
 redis:
   auth:


### PR DESCRIPTION
… one in dev.